### PR TITLE
fix `splits all hyphens`, return @-@

### DIFF
--- a/sacremoses/tokenize.py
+++ b/sacremoses/tokenize.py
@@ -41,7 +41,7 @@ class MosesTokenizer(object):
 
     # Splits all hypens (regardless of circumstances), e.g.
     # 'foo -- bar' -> 'foo @-@ @-@ bar' , 'foo-bar' -> 'foo @-@ bar'
-    AGGRESSIVE_HYPHEN_SPLIT = u'([{alphanum}])\-(?=[{alphanum}])'.format(alphanum=IsAlnum), r'\1 \@-\@ '
+    AGGRESSIVE_HYPHEN_SPLIT = u'([{alphanum}])\-(?=[{alphanum}])'.format(alphanum=IsAlnum), r'\1 @-@ '
 
     # Make multi-dots stay together.
     REPLACE_DOT_WITH_LITERALSTRING_1 = r'\.([\.]+)', ' DOTMULTI\1'


### PR DESCRIPTION
if the input is `non-smoking`
the raw version return `non \@-\@ smoking`
the new vertion return `non @-@ smoking`
And the Detokenizer return `non-smoking` now.