### PR TITLE
Fix bug in detokenize cli when processes == 1

### DIFF
--- a/sacremoses/cli.py
+++ b/sacremoses/cli.py
@@ -74,7 +74,7 @@ def detokenize_file(language, processes, xml_unescape, encoding):
             # so just process line by line normally.
             if processes == 1:
                 for line in tqdm(fin.readlines()):
-                    print(moses_detokenize(line), end='\n', file=fout)
+                    print(moses_detokenize(str.split(line)), end='\n', file=fout)
             else:
                 document_iterator = map(str.split, fin.readlines())
                 for outline in parallelize_preprocess(moses_detokenize, document_iterator, processes, progress_bar=True):


### PR DESCRIPTION
When `-j=1`, before:
```
G u t a c h: M e h r S i c h e r h e i t f ü r F u ß g ä n g e r
```

After:
```
Gutach: Mehr Sicherheit für Fußgänger
```