### PR TITLE
Added normalizer from #17

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,8 +70,17 @@ True
 >>> mtr = MosesTruecaser('big.truecasemodel')
 >>> mtr.truecase("THE ADVENTURES OF SHERLOCK HOLMES")
 ['the', 'adventures', 'of', 'Sherlock', 'Holmes']
->>> print(mtr.truecase("THE ADVENTURES OF SHERLOCK HOLMES", return_str=True)
+>>> mtr.truecase("THE ADVENTURES OF SHERLOCK HOLMES", return_str=True
 'the adventures of Sherlock Holmes'
+```
+
+**Normalizer**
+
+```
+>>> from sacremoses import MosesPunctNormalizer
+>>> mpn = MosesPunctNormalizer()
+>>> mpn.normalize('THIS EBOOK IS OTHERWISE PROVIDED TO YOU "AS-IS."')
+'THIS EBOOK IS OTHERWISE PROVIDED TO YOU "AS-IS."'
 ```
 
 
@@ -185,4 +194,21 @@ Options:
 
 $ sacremoses detruecase -j 4 < big.txt.tok.true > big.txt.tok.true.detrue
 100%|█████████████████████████████████| 128457/128457 [00:04<00:00, 26945.16it/s]
+```
+
+**Normalize**
+
+```shell
+$ sacremoses normalize --help
+Usage: sacremoses normalize [OPTIONS]
+
+Options:
+  -l, --language TEXT           Use language specific rules when normalizing.
+  -j, --processes INTEGER       No. of processes.
+  -q, --normalize-quote-commas  Normalize quotations and commas.
+  -d, --normalize-numbers       Normalize number.
+  -e, --encoding TEXT           Specify encoding of file.
+  -h, --help                    Show this message and exit.
+
+$ sacremoses normalize -j 4 < big.txt > big.txt.norm.cli  100%|███████████████████████████████████████████████████████████████████████| 128457/128457 [00:09<00:00, 13096.23it/s]
 ```

--- a/sacremoses/__init__.py
+++ b/sacremoses/__init__.py
@@ -2,4 +2,5 @@
 from sacremoses.corpus import *
 from sacremoses.tokenize import *
 from sacremoses.truecase import *
+from sacremoses.normalize import *
 #from sacremoses.subwords import *

--- a/sacremoses/normalize.py
+++ b/sacremoses/normalize.py
@@ -75,12 +75,12 @@ class MosesPunctNormalizer:
     ]
 
     OTHER = [
-        (r'(\d) (\d)', r'\g<1>.\g<2>'),
+        (u'(\d){}(\d)'.format(u"\u00A0"), r'\g<1>.\g<2>'),
     ]
 
     def __init__(self, lang='en', penn=False,
                  norm_quote_commas=True,
-                 norm_numbers=False):
+                 norm_numbers=True):
         """
         :param language: The two-letter language code.
         :type lang: str
@@ -114,5 +114,5 @@ class MosesPunctNormalizer:
         Returns a string with normalized punctuation.
         """
         for regexp, substitution in self.substitutions:
-            text = re.sub(regexp, substitution, text)
+            text = re.sub(regexp, substitution, text_type(text))
         return text

--- a/sacremoses/normalize.py
+++ b/sacremoses/normalize.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import re
+
+from six import text_type
+
+
+class MosesPunctNormalizer:
+    """
+    This is a Python port of the Moses punctuation normalizer from
+    https://github.com/moses-smt/mosesdecoder/blob/master/scripts/tokenizer/normalize-punctuation.perl
+    """
+    EXTRA_WHITESPACE = [ # lines 21 - 30
+        (r'\r', r''),
+        (r'\(', r' ('),
+        (r'\)', r') '),
+        (r' +', r' '),
+        (r'\) ([.!:?;,])', r')\g<1>'),
+        (r'\( ', r'('),
+        (r' \)', r')'),
+        (r'(\d) %', r'\g<1>%'),
+        (r' :', r':'),
+        (r' ;', r';'),
+    ]
+
+    NORMALIZE_UNICODE_IF_NOT_PENN = [ # lines 33 - 34
+        (r'`', r"'"),
+        (r"''", r' " '),
+    ]
+
+    NORMALIZE_UNICODE = [ # lines 37 - 50
+        (u'„', r'"'),
+        (u'“', r'"'),
+        (u'”', r'"'),
+        (u'–', r'-'),
+        (u'—', r' - '),
+        (r' +', r' '),
+        (u'´', r"'"),
+    ]
+
+    FRENCH_QUOTES = [ # lines 52 - 57
+        (u' « ', r'"'),
+        (u'« ', r'"'),
+        (u'«', r'"'),
+        (u' » ', r'"'),
+        (u' »', r'"'),
+        (u'»', r'"'),
+    ]
+
+    HANDLE_PSEUDO_SPACES = [ # lines 59 - 67
+        (r' %', r'%'),
+        (u'nº ', u'nº '),
+        (r' :', r':'),
+        (u' ºC', u' ºC'),
+        (r' cm', r' cm'),
+        (r' \?', r'\?'),
+        (r' \!', r'\!'),
+        (r' ;', r';'),
+        (r', ', r', '),
+        (r' +', r' '),
+    ]
+
+    EN_QUOTATION_FOLLOWED_BY_COMMA = [
+        (r'"([,.]+)', r'\g<1>"'),
+    ]
+
+    DE_ES_FR_QUOTATION_FOLLOWED_BY_COMMA = [
+        (r',"', r'",'),
+        (r'(\.+)"(\s*[^<])', r'"\g<1>\g<2>'), # don't fix period at end of sentence
+    ]
+
+    DE_ES_CZ_CS_FR = [
+        (r'(\d) (\d)', r'\g<1>,\g<2>'),
+    ]
+
+    OTHER = [
+        (r'(\d) (\d)', r'\g<1>.\g<2>'),
+    ]
+
+    def __init__(self, lang='en', penn=False,
+                 norm_quote_commas=True,
+                 norm_numbers=False):
+        """
+        :param language: The two-letter language code.
+        :type lang: str
+        :param penn: Keep Penn Treebank style quotations.
+        :type penn: bool
+        :param norm_quote: Keep Penn Treebank style quotations.
+        :type norm_quote: bool
+        """
+        self.substitutions = self.EXTRA_WHITESPACE
+
+        if not penn:
+            self.substitutions += self.NORMALIZE_UNICODE_IF_NOT_PENN
+        self.substitutions += self.NORMALIZE_UNICODE
+        self.substitutions += self.FRENCH_QUOTES
+        self.substitutions += self.HANDLE_PSEUDO_SPACES
+
+        if norm_quote_commas:
+            if lang == 'en':
+                self.substitutions += self.EN_QUOTATION_FOLLOWED_BY_COMMA
+            elif lang in ['de', 'es', 'fr']:
+                self.substitutions += self.DE_ES_FR_QUOTATION_FOLLOWED_BY_COMMA
+
+        if norm_numbers:
+            if lang in ['de', 'es', 'cz', 'cs', 'fr']:
+                self.substitutions += self.DE_ES_CZ_CS_FR
+            else:
+                self.substitutions += self.OTHER
+
+    def normalize(self, text):
+        """
+        Returns a string with normalized punctuation.
+        """
+        for regexp, substitution in self.substitutions:
+            text = re.sub(regexp, substitution, text)
+        return text

--- a/sacremoses/test/test_normalizer.py
+++ b/sacremoses/test/test_normalizer.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+
+"""
+Tests for MosesTokenizer
+"""
+
+import io
+import os
+import unittest
+
+from six import text_type
+
+from sacremoses.normalize import  MosesPunctNormalizer
+
+class TestNormalizer(unittest.TestCase):
+    def test_moses_normalize_documents(self):
+        moses = MosesTruecaser()
+        # Examples from normalizing big.txt
+        inputs = ["The United States in 1805 (color map)                 _Facing_     193",
+                  "=Formation of the Constitution.=--(1) The plans before the convention,",
+                  "directions--(1) The infective element must be eliminated. When the ulcer",
+                  "College of Surgeons, Edinburgh.)]"]
+        expected = ["The United States in 1805 (color map) _Facing_ 193",
+                    "=Formation of the Constitution.=-- (1) The plans before the convention,",
+                    "directions-- (1) The infective element must be eliminated. When the ulcer",
+                    "College of Surgeons, Edinburgh.) ]"]
+        for text, expect in zip(inputs, expected):
+            assert moses.normalize(text) == expect
+
+    def test_moses_normalize_quote_comma(self):
+        moses_norm_quote = MosesPunctNormalizer('en', norm_quote_commas=True)
+        moses_no_norm_quote = MosesPunctNormalizer('en', norm_quote_commas=False)
+        text = 'THIS EBOOK IS OTHERWISE PROVIDED TO YOU "AS-IS".'
+
+        expected_norm_quote = 'THIS EBOOK IS OTHERWISE PROVIDED TO YOU "AS-IS."'
+        assert moses_norm_quote.normalize(text) == expected_norm_quote
+
+        expected_no_norm_quote = 'THIS EBOOK IS OTHERWISE PROVIDED TO YOU "AS-IS".'
+        assert moses_no_norm_quote.normalize(text) == expected_no_norm_quote
+
+    def test_moses_normalize_numbers(self):
+        # See https://stackoverflow.com/a/55233871/610569
+        moses_norm_num = MosesPunctNormalizer('en', norm_numbers=True)
+        moses_no_norm_num = MosesPunctNormalizer('en', norm_numbers=False)
+
+        text = u'12{}123'.format(u'\u00A0')
+        expected = u'12.123'
+
+        assert moses_norm_num.normalize(text) == expected
+        assert moses_no_norm_num.normalize(text) == text

--- a/sacremoses/test/test_normalizer.py
+++ b/sacremoses/test/test_normalizer.py
@@ -10,11 +10,11 @@ import unittest
 
 from six import text_type
 
-from sacremoses.normalize import  MosesPunctNormalizer
+from sacremoses.normalize import MosesPunctNormalizer
 
 class TestNormalizer(unittest.TestCase):
     def test_moses_normalize_documents(self):
-        moses = MosesTruecaser()
+        moses = MosesPunctNormalizer()
         # Examples from normalizing big.txt
         inputs = ["The United States in 1805 (color map)                 _Facing_     193",
                   "=Formation of the Constitution.=--(1) The plans before the convention,",
@@ -45,6 +45,7 @@ class TestNormalizer(unittest.TestCase):
 
         text = u'12{}123'.format(u'\u00A0')
         expected = u'12.123'
-
         assert moses_norm_num.normalize(text) == expected
-        assert moses_no_norm_num.normalize(text) == text
+
+        text = expected = u'12 123'
+        assert moses_no_norm_num.normalize(text) == expected

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ sacremoses=sacremoses.cli:cli
 setup(
   name = 'sacremoses',
   packages = ['sacremoses'],
-  version = '0.0.10',
+  version = '0.0.11',
   description = 'SacreMoses',
   long_description = 'LGPL MosesTokenizer in Python',
   author = '',


### PR DESCRIPTION
Thanks @Patdue for #17, I've refactored the code a little and use the `re.sub` to be consistent as well as it's known to be a little faster than `str.replace`. 