### PR TITLE
Change name/behavior of `isalpha` in `MosesTokenizer`

### DIFF
--- a/sacremoses/test/test_tokenizer.py
+++ b/sacremoses/test/test_tokenizer.py
@@ -55,6 +55,12 @@ class TestTokenzier(unittest.TestCase):
 
         assert moses.tokenize(text) == expected_tokens
 
+    def test_dot_splitting(self):
+        moses = MosesTokenizer()
+        text = "The meeting will take place at 11:00 a.m. Tuesday."
+        expected_tokens = "The meeting will take place at 11 : 00 a.m. Tuesday .".split()
+        self.assertEqual(moses.tokenize(text), expected_tokens)
+
 
 class TestDetokenizer(unittest.TestCase):
     def test_moses_detokenize(self):

--- a/sacremoses/tokenize.py
+++ b/sacremoses/tokenize.py
@@ -229,8 +229,8 @@ class MosesTokenizer(object):
     def islower(self, text):
         return not set(text).difference(set(self.IsLower))
 
-    def isalpha(self, text):
-        return not set(text).difference(set(self.IsAlpha))
+    def isanyalpha(self, text):
+        return len(set(text).intersection(set(self.IsAlpha))) > 0
 
     def has_numeric_only(self, text):
         return bool(re.search(r'(.*)[\s]+(\#NUMERIC_ONLY\#)', text))
@@ -251,7 +251,7 @@ class MosesTokenizer(object):
                 #      does not contain #NUMERIC_ONLY#
                 # iii. the token is not the last token and that the
                 #      next token contains all lowercase.
-                if (('.' in prefix and self.isalpha(prefix)) or
+                if (('.' in prefix and self.isanyalpha(prefix)) or
                         (prefix in self.NONBREAKING_PREFIXES and
                          prefix not in self.NUMERIC_ONLY_PREFIXES) or
                         (i != num_tokens - 1 and self.islower(tokens[i + 1]))):

--- a/sacremoses/tokenize.py
+++ b/sacremoses/tokenize.py
@@ -230,7 +230,7 @@ class MosesTokenizer(object):
         return not set(text).difference(set(self.IsLower))
 
     def isanyalpha(self, text):
-        return len(set(text).intersection(set(self.IsAlpha))) > 0
+        return any(set(text).intersection(set(self.IsAlpha)))
 
     def has_numeric_only(self, text):
         return bool(re.search(r'(.*)[\s]+(\#NUMERIC_ONLY\#)', text))


### PR DESCRIPTION
There seems to be a discrepancy between the output of SacreMoses and the Moses tokenizer on abbreviations (e.g. "U.S."/"U.S .", "a.m."/"a.m .", etc.) caused by the `isalpha` method of `MosesTokenizer` that returns whether all (rather than any) of the tokens are in the `IsAlpha`.

Moses has [changed](https://github.com/moses-smt/mosesdecoder/commit/9fc964da7fbe91b1fb3da69ed192cf9be217d256#diff-c90b302f7924f17be86aacec242a6049) to always split final dots. I do not know what the desired behavior of SacreMoses is, though I think it would be really useful to have access to past behavior for replicating experiments done with previous versions of the Moses tokenizer.