### PR TITLE
Handle trailing dot apostrophe.

### DIFF
--- a/sacremoses/test/test_tokenizer.py
+++ b/sacremoses/test/test_tokenizer.py
@@ -61,6 +61,12 @@ class TestTokenzier(unittest.TestCase):
         expected_tokens = "The meeting will take place at 11 : 00 a.m. Tuesday .".split()
         self.assertEqual(moses.tokenize(text), expected_tokens)
 
+    def test_trailing_dot_apostrophe(self):
+        moses = MosesTokenizer()
+        text = "'Hello.'"
+        expected_tokens = "&apos;Hello . &apos;".split()
+        self.assertEqual(moses.tokenize(text), expected_tokens)
+
     def test_protect_patterns(self):
         moses = MosesTokenizer()
         text = "this is a webpage https://stackoverflow.com/questions/6181381/how-to-print-variables-in-perl that kicks ass"

--- a/sacremoses/tokenize.py
+++ b/sacremoses/tokenize.py
@@ -334,6 +334,8 @@ class MosesTokenizer(object):
         # Cleans up extraneous spaces.
         regexp, substitution = self.DEDUPLICATE_SPACE
         text = re.sub(regexp, substitution, text).strip()
+        # Split trailing ".'".
+        text = re.sub("\.\' ?$", " . ' ", text)
         # Restore multidots.
         text = self.restore_multidots(text)
         if escape:


### PR DESCRIPTION
Not sure if this is the desired behavior of SacreMoses, but the Perl implementation of Moses splits trailing occurrences of a dot followed by an apostrophe:  https://github.com/moses-smt/mosesdecoder/blob/187a75cb5596c8e4362c66c62de395e2b7d3a64a/scripts/tokenizer/tokenizer.perl#L375.