### PR TITLE
`pkgutil` and Test for `corpus.py`

### DIFF
--- a/sacremoses/corpus.py
+++ b/sacremoses/corpus.py
@@ -19,7 +19,7 @@ class Perluniprops:
                             'Symbol', 'Lowercase_Letter', 'Titlecase_Letter',
                             'Uppercase_Letter']
 
-    def chars(self, category=None, fileids=None):
+    def chars(self, category=None):
         """
         This module returns a list of characters from  the Perl Unicode Properties.
         They are very useful when porting Perl tokenizers to Python.

--- a/sacremoses/corpus.py
+++ b/sacremoses/corpus.py
@@ -3,6 +3,7 @@
 
 import io
 import os
+import pkgutil
 
 class Perluniprops:
     """
@@ -11,24 +12,21 @@ class Perluniprops:
     The files in the perluniprop.zip are extracted using the Unicode::Tussle
     module from http://search.cpan.org/~bdfoy/Unicode-Tussle-1.11/lib/Unicode/Tussle.pm
     """
-    def __init__(self):
-        self.datadir = os.path.dirname(os.path.abspath(__file__)) + '/data/perluniprops/'
-        # These are categories similar to the Perl Unicode Properties
-        self.available_categories = ['Close_Punctuation', 'Currency_Symbol',
-                                     'IsAlnum', 'IsAlpha', 'IsLower', 'IsN', 'IsSc',
-                                     'IsSo', 'IsUpper', 'Line_Separator', 'Number',
-                                     'Open_Punctuation', 'Punctuation', 'Separator',
-                                     'Symbol',
-                                     'Lowercase_Letter.txt',
-                                     'Titlecase_Letter.txt',
-                                     'Uppercase_Letter.txt']
+    # These are categories similar to the Perl Unicode Properties
+    available_categories = ['Close_Punctuation', 'Currency_Symbol', 'IsAlnum',
+                            'IsAlpha', 'IsLower', 'IsN', 'IsSc', 'IsSo',
+                            'IsUpper', 'Line_Separator', 'Number',
+                            'Open_Punctuation', 'Punctuation', 'Separator',
+                            'Symbol', 'Lowercase_Letter', 'Titlecase_Letter',
+                            'Uppercase_Letter']
 
     def chars(self, category=None, fileids=None):
         """
         This module returns a list of characters from  the Perl Unicode Properties.
         They are very useful when porting Perl tokenizers to Python.
 
-            >>> from profanebleu.corpus import perluniprops as pup
+            >>> from sacremoses.corpus import Perluniprops
+            >>> pup = Perluniprops()
             >>> pup.chars('Open_Punctuation')[:5] == [u'(', u'[', u'{', u'\u0f3a', u'\u0f3c']
             True
             >>> pup.chars('Currency_Symbol')[:5] == [u'$', u'\xa2', u'\xa3', u'\xa4', u'\xa5']
@@ -38,9 +36,9 @@ class Perluniprops:
 
         :return: a generator of characters given the specific unicode character category
         """
-        with io.open(self.datadir+category+'.txt', encoding='utf8') as fin:
-            for ch in fin.read().strip():
-                yield ch
+        relative_path = os.path.join("data", "perluniprops", category + ".txt")
+        binary_data = pkgutil.get_data("sacremoses", relative_path)
+        return binary_data.decode("utf-8")
 
 
 class NonbreakingPrefixes:
@@ -80,7 +78,8 @@ class NonbreakingPrefixes:
         This module returns a list of nonbreaking prefixes for the specified
         language(s).
 
-            >>> from profanebleu.corpus import nonbreaking_prefixes as nbp
+            >>> from sacremoses.corpus import NonbreakingPrefixes
+            >>> nbp = NonbreakingPrefixes()
             >>> nbp.words('en')[:10] == [u'A', u'B', u'C', u'D', u'E', u'F', u'G', u'H', u'I', u'J']
             True
             >>> nbp.words('ta')[:5] == [u'\u0b85', u'\u0b86', u'\u0b87', u'\u0b88', u'\u0b89']
@@ -99,10 +98,11 @@ class NonbreakingPrefixes:
             filenames = ['nonbreaking_prefix.en']
 
         for filename in filenames:
-            with io.open(self.datadir+filename, encoding='utf8') as fin:
-                for line in fin:
-                    line = line.strip()
-                    if line and not line.startswith(ignore_lines_startswith):
-                        yield line
+            relative_path = os.path.join("data", "nonbreaking_prefixes", filename)
+            binary_data = pkgutil.get_data("sacremoses", relative_path)
+            for line in binary_data.decode("utf-8").splitlines():
+                line = line.strip()
+                if line and not line.startswith(ignore_lines_startswith):
+                    yield line
 
 __all__ = ['Perluniprops', 'NonbreakingPrefixes']

--- a/sacremoses/corpus.py
+++ b/sacremoses/corpus.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-import io
 import os
 import pkgutil
 

--- a/sacremoses/corpus.py
+++ b/sacremoses/corpus.py
@@ -27,18 +27,18 @@ class Perluniprops:
 
             >>> from sacremoses.corpus import Perluniprops
             >>> pup = Perluniprops()
-            >>> pup.chars('Open_Punctuation')[:5] == [u'(', u'[', u'{', u'\u0f3a', u'\u0f3c']
+            >>> list(pup.chars('Open_Punctuation'))[:5] == [u'(', u'[', u'{', u'\u0f3a', u'\u0f3c']
             True
-            >>> pup.chars('Currency_Symbol')[:5] == [u'$', u'\xa2', u'\xa3', u'\xa4', u'\xa5']
+            >>> list(pup.chars('Currency_Symbol'))[:5] == [u'$', u'\xa2', u'\xa3', u'\xa4', u'\xa5']
             True
-            >>> pup.available_categories
-            ['Close_Punctuation', 'Currency_Symbol', 'IsAlnum', 'IsAlpha', 'IsLower', 'IsN', 'IsSc', 'IsSo', 'IsUpper', 'Line_Separator', 'Number', 'Open_Punctuation', 'Punctuation', 'Separator', 'Symbol']
+            >>> pup.available_categories[:5]
+            ['Close_Punctuation', 'Currency_Symbol', 'IsAlnum', 'IsAlpha', 'IsLower']
 
         :return: a generator of characters given the specific unicode character category
         """
         relative_path = os.path.join("data", "perluniprops", category + ".txt")
         binary_data = pkgutil.get_data("sacremoses", relative_path)
-        return binary_data.decode("utf-8")
+        yield from binary_data.decode("utf-8")
 
 
 class NonbreakingPrefixes:
@@ -80,9 +80,9 @@ class NonbreakingPrefixes:
 
             >>> from sacremoses.corpus import NonbreakingPrefixes
             >>> nbp = NonbreakingPrefixes()
-            >>> nbp.words('en')[:10] == [u'A', u'B', u'C', u'D', u'E', u'F', u'G', u'H', u'I', u'J']
+            >>> list(nbp.words('en'))[:10] == [u'A', u'B', u'C', u'D', u'E', u'F', u'G', u'H', u'I', u'J']
             True
-            >>> nbp.words('ta')[:5] == [u'\u0b85', u'\u0b86', u'\u0b87', u'\u0b88', u'\u0b89']
+            >>> list(nbp.words('ta'))[:5] == [u'\u0b85', u'\u0b86', u'\u0b87', u'\u0b88', u'\u0b89']
             True
 
         :return: a generator words for the specified language(s).

--- a/sacremoses/corpus.py
+++ b/sacremoses/corpus.py
@@ -37,7 +37,8 @@ class Perluniprops:
         """
         relative_path = os.path.join("data", "perluniprops", category + ".txt")
         binary_data = pkgutil.get_data("sacremoses", relative_path)
-        yield from binary_data.decode("utf-8")
+        for ch in binary_data.decode("utf-8"):
+            yield ch
 
 
 class NonbreakingPrefixes:

--- a/sacremoses/test/test_corpus.py
+++ b/sacremoses/test/test_corpus.py
@@ -8,12 +8,12 @@ import sys
 import doctest
 import unittest
 
-from sacremoses.corpus import Perluniprops, NonbreakingPrefixes
+from sacremoses import corpus
 
 
 class CorpusTest(unittest.TestCase):
     def test_perluniprops_chars_sanity_check(self):
-        perluniprops = Perluniprops()
+        perluniprops = corpus.Perluniprops()
         for category in perluniprops.available_categories:
             if sys.version_info[0] >= 3: # Python 3
                 with self.subTest(category=category):
@@ -28,14 +28,14 @@ class CorpusTest(unittest.TestCase):
                                 True)
                 
     def test_perluniprops_chars_manual(self):
-        perluniprops = Perluniprops()
+        perluniprops = corpus.Perluniprops()
         self.assertListEqual(list(perluniprops.chars('Open_Punctuation'))[:5],
                              [u'(', u'[', u'{', u'\u0f3a', u'\u0f3c'])
         self.assertListEqual(list(perluniprops.chars('Currency_Symbol'))[:5],
                              [u'$', u'\xa2', u'\xa3', u'\xa4', u'\xa5'])
 
     def test_nonbreaking_prefixes_sanity_check(self):
-        nonbreaking_prefixes = NonbreakingPrefixes()
+        nonbreaking_prefixes = corpus.NonbreakingPrefixes()
         for language in nonbreaking_prefixes.available_langs.values():
             if sys.version_info[0] >= 3: # Python 3
                 with self.subTest(language=language):
@@ -50,7 +50,7 @@ class CorpusTest(unittest.TestCase):
                                 True)
 
     def test_nonbreaking_prefixes_manual(self):
-        nonbreaking_prefixes = NonbreakingPrefixes()
+        nonbreaking_prefixes = corpus.NonbreakingPrefixes()
         self.assertListEqual(list(nonbreaking_prefixes.words('en'))[:10],
                              [u'A', u'B', u'C', u'D', u'E', u'F', u'G', u'H', u'I', u'J'])
         self.assertListEqual(list(nonbreaking_prefixes.words('ta'))[:5],

--- a/sacremoses/test/test_corpus.py
+++ b/sacremoses/test/test_corpus.py
@@ -23,7 +23,7 @@ class CorpusTest(unittest.TestCase):
                         count += 1
                     self.assertGreater(count, 0)
             else:
-                self.assertEqual(all(instance(char, str) for char in 
+                self.assertEqual(all(isinstance(char, str) for char in 
                                      perluniprops.chars(category=category)),
                                 True)
                 
@@ -45,7 +45,7 @@ class CorpusTest(unittest.TestCase):
                         count += 1
                     self.assertGreater(count, 0)
             else:
-                self.assertEqual(all(instance(word, str) for word in 
+                self.assertEqual(all(isinstance(word, str) for word in 
                                      nonbreaking_prefixes.words(lang=language)),
                                 True)
 

--- a/sacremoses/test/test_corpus.py
+++ b/sacremoses/test/test_corpus.py
@@ -4,6 +4,7 @@
 Tests for corpus.py
 """
 
+import doctest
 import unittest
 
 from sacremoses import corpus
@@ -43,3 +44,8 @@ class CorpusTest(unittest.TestCase):
                              [u'A', u'B', u'C', u'D', u'E', u'F', u'G', u'H', u'I', u'J'])
         self.assertListEqual(list(nonbreaking_prefixes.words('ta'))[:5],
                              [u'\u0b85', u'\u0b86', u'\u0b87', u'\u0b88', u'\u0b89'])
+
+
+def load_tests(loader, tests, ignore):
+    tests.addTests(doctest.DocTestSuite(corpus))
+    return tests

--- a/sacremoses/test/test_corpus.py
+++ b/sacremoses/test/test_corpus.py
@@ -4,42 +4,51 @@
 Tests for corpus.py
 """
 
+import sys
 import doctest
 import unittest
 
-from sacremoses import corpus
+from sacremoses.corpus import Perluniprops, NonbreakingPrefixes
 
 
 class CorpusTest(unittest.TestCase):
     def test_perluniprops_chars_sanity_check(self):
-        perluniprops = corpus.Perluniprops()
+        perluniprops = Perluniprops()
         for category in perluniprops.available_categories:
-            with self.subTest(category=category):
-                count = 0
-                for char in perluniprops.chars(category=category):
-                    self.assertIsInstance(char, str)
-                    count += 1
-                self.assertGreater(count, 0)
-
+            if sys.version_info[0] >= 3: # Python 3
+                with self.subTest(category=category):
+                    count = 0
+                    for char in perluniprops.chars(category=category):
+                        self.assertIsInstance(char, str)
+                        count += 1
+                    self.assertGreater(count, 0)
+            else:
+                self.assert(all(instance(char, str) for char in 
+                                perluniprops.chars(category=category)))
+                
     def test_perluniprops_chars_manual(self):
-        perluniprops = corpus.Perluniprops()
+        perluniprops = Perluniprops()
         self.assertListEqual(list(perluniprops.chars('Open_Punctuation'))[:5],
                              [u'(', u'[', u'{', u'\u0f3a', u'\u0f3c'])
         self.assertListEqual(list(perluniprops.chars('Currency_Symbol'))[:5],
                              [u'$', u'\xa2', u'\xa3', u'\xa4', u'\xa5'])
 
     def test_nonbreaking_prefixes_sanity_check(self):
-        nonbreaking_prefixes = corpus.NonbreakingPrefixes()
+        nonbreaking_prefixes = NonbreakingPrefixes()
         for language in nonbreaking_prefixes.available_langs.values():
-            with self.subTest(language=language):
-                count = 0
-                for char in nonbreaking_prefixes.words(lang=language):
-                    self.assertIsInstance(char, str)
-                    count += 1
-                self.assertGreater(count, 0)
+            if sys.version_info[0] >= 3: # Python 3
+                with self.subTest(language=language):
+                    count = 0
+                    for word in nonbreaking_prefixes.words(lang=language):
+                        self.assertIsInstance(word, str)
+                        count += 1
+                    self.assertGreater(count, 0)
+            else:
+                self.assert(all(instance(word, str) for word in 
+                                nonbreaking_prefixes.words(lang=language)))
 
     def test_nonbreaking_prefixes_manual(self):
-        nonbreaking_prefixes = corpus.NonbreakingPrefixes()
+        nonbreaking_prefixes = NonbreakingPrefixes()
         self.assertListEqual(list(nonbreaking_prefixes.words('en'))[:10],
                              [u'A', u'B', u'C', u'D', u'E', u'F', u'G', u'H', u'I', u'J'])
         self.assertListEqual(list(nonbreaking_prefixes.words('ta'))[:5],

--- a/sacremoses/test/test_corpus.py
+++ b/sacremoses/test/test_corpus.py
@@ -23,8 +23,9 @@ class CorpusTest(unittest.TestCase):
                         count += 1
                     self.assertGreater(count, 0)
             else:
-                self.assert(all(instance(char, str) for char in 
-                                perluniprops.chars(category=category)))
+                self.assertEqual(all(instance(char, str) for char in 
+                                     perluniprops.chars(category=category)),
+                                True)
                 
     def test_perluniprops_chars_manual(self):
         perluniprops = Perluniprops()
@@ -44,8 +45,9 @@ class CorpusTest(unittest.TestCase):
                         count += 1
                     self.assertGreater(count, 0)
             else:
-                self.assert(all(instance(word, str) for word in 
-                                nonbreaking_prefixes.words(lang=language)))
+                self.assertEqual(all(instance(word, str) for word in 
+                                     nonbreaking_prefixes.words(lang=language))m
+                                True)
 
     def test_nonbreaking_prefixes_manual(self):
         nonbreaking_prefixes = NonbreakingPrefixes()

--- a/sacremoses/test/test_corpus.py
+++ b/sacremoses/test/test_corpus.py
@@ -8,6 +8,8 @@ import sys
 import doctest
 import unittest
 
+from six import text_type
+
 from sacremoses import corpus
 
 
@@ -23,7 +25,7 @@ class CorpusTest(unittest.TestCase):
                         count += 1
                     self.assertGreater(count, 0)
             else:
-                self.assertEqual(all(isinstance(char, str) for char in 
+                self.assertEqual(all(isinstance(char, text_type) for char in 
                                      perluniprops.chars(category=category)),
                                 True)
                 
@@ -45,7 +47,7 @@ class CorpusTest(unittest.TestCase):
                         count += 1
                     self.assertGreater(count, 0)
             else:
-                self.assertEqual(all(isinstance(word, str) for word in 
+                self.assertEqual(all(isinstance(word, text_type) for word in 
                                      nonbreaking_prefixes.words(lang=language)),
                                 True)
 

--- a/sacremoses/test/test_corpus.py
+++ b/sacremoses/test/test_corpus.py
@@ -46,7 +46,7 @@ class CorpusTest(unittest.TestCase):
                     self.assertGreater(count, 0)
             else:
                 self.assertEqual(all(instance(word, str) for word in 
-                                     nonbreaking_prefixes.words(lang=language))m
+                                     nonbreaking_prefixes.words(lang=language)),
                                 True)
 
     def test_nonbreaking_prefixes_manual(self):

--- a/sacremoses/test/test_corpus.py
+++ b/sacremoses/test/test_corpus.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+
+"""
+Tests for corpus.py
+"""
+
+import unittest
+
+from sacremoses import corpus
+
+
+class CorpusTest(unittest.TestCase):
+    def test_perluniprops_chars_sanity_check(self):
+        perluniprops = corpus.Perluniprops()
+        for category in perluniprops.available_categories:
+            with self.subTest(category=category):
+                count = 0
+                for char in perluniprops.chars(category=category):
+                    self.assertIsInstance(char, str)
+                    count += 1
+                self.assertGreater(count, 0)
+
+    def test_perluniprops_chars_manual(self):
+        perluniprops = corpus.Perluniprops()
+        self.assertListEqual(list(perluniprops.chars('Open_Punctuation'))[:5],
+                             [u'(', u'[', u'{', u'\u0f3a', u'\u0f3c'])
+        self.assertListEqual(list(perluniprops.chars('Currency_Symbol'))[:5],
+                             [u'$', u'\xa2', u'\xa3', u'\xa4', u'\xa5'])
+
+    def test_nonbreaking_prefixes_sanity_check(self):
+        nonbreaking_prefixes = corpus.NonbreakingPrefixes()
+        for language in nonbreaking_prefixes.available_langs.values():
+            with self.subTest(language=language):
+                count = 0
+                for char in nonbreaking_prefixes.words(lang=language):
+                    self.assertIsInstance(char, str)
+                    count += 1
+                self.assertGreater(count, 0)
+
+    def test_nonbreaking_prefixes_manual(self):
+        nonbreaking_prefixes = corpus.NonbreakingPrefixes()
+        self.assertListEqual(list(nonbreaking_prefixes.words('en'))[:10],
+                             [u'A', u'B', u'C', u'D', u'E', u'F', u'G', u'H', u'I', u'J'])
+        self.assertListEqual(list(nonbreaking_prefixes.words('ta'))[:5],
+                             [u'\u0b85', u'\u0b86', u'\u0b87', u'\u0b88', u'\u0b89'])

--- a/sacremoses/test/test_tokenizer.py
+++ b/sacremoses/test/test_tokenizer.py
@@ -61,12 +61,6 @@ class TestTokenzier(unittest.TestCase):
         expected_tokens = "The meeting will take place at 11 : 00 a.m. Tuesday .".split()
         self.assertEqual(moses.tokenize(text), expected_tokens)
 
-    def test_period_apostrophe(self):
-        moses = MosesTokenizer()
-        text = "'Hello.'"
-        expected_tokens = "&apos;Hello . &apos;".split()
-        self.assertEqual(moses.tokenize(text), expected_tokens)
-
     def test_protect_patterns(self):
         moses = MosesTokenizer()
         text = "this is a webpage https://stackoverflow.com/questions/6181381/how-to-print-variables-in-perl that kicks ass"

--- a/sacremoses/test/test_tokenizer.py
+++ b/sacremoses/test/test_tokenizer.py
@@ -61,6 +61,12 @@ class TestTokenzier(unittest.TestCase):
         expected_tokens = "The meeting will take place at 11 : 00 a.m. Tuesday .".split()
         self.assertEqual(moses.tokenize(text), expected_tokens)
 
+    def test_period_apostrophe(self):
+        moses = MosesTokenizer()
+        text = "'Hello.'"
+        expected_tokens = "&apos;Hello . &apos;".split()
+        self.assertEqual(moses.tokenize(text), expected_tokens)
+
 
 class TestDetokenizer(unittest.TestCase):
     def test_moses_detokenize(self):


### PR DESCRIPTION
Add a test for `corpus.py` as well as change it to use `pkgutil` to load the files which should allow loading the values even if the files aren't packaged as they are in the repo (e.g. in a standalone executable).

I'm happy to remove the `pkgutil` changes if you think they add unnecessary complexity.