### PR TITLE
add missing import in utils

### DIFF
--- a/sacremoses/util.py
+++ b/sacremoses/util.py
@@ -6,6 +6,8 @@ try: # Python3
 except ImportError: # Python2
     from itertools import izip_longest as zip_longest
 
+from xml.sax.saxutils import escape, unescape
+
 from joblib import Parallel, delayed
 from tqdm import tqdm
 


### PR DESCRIPTION
`escape` and `unescape` imports were missing in `utils.py`.