### PR TITLE
Added feature to add custom nb prefixes

### DIFF
--- a/sacremoses/__init__.py
+++ b/sacremoses/__init__.py
@@ -5,4 +5,4 @@ from sacremoses.normalize import *
 
 # from sacremoses.subwords import *
 
-__version__ = "0.0.31"
+__version__ = "0.0.32"

--- a/sacremoses/cli.py
+++ b/sacremoses/cli.py
@@ -62,6 +62,11 @@ def cli():
     "-p",
     help="Specify file with patters to be protected in tokenisation.",
 )
+@click.option(
+    "--custom-nb-prefixes",
+    "-c",
+    help="Specify a custom non-breaking prefixes file, add prefixes to the default ones from the specified language.",
+)
 @click.option("--encoding", "-e", default="utf8", help="Specify encoding of file.")
 def tokenize_file(
     language,
@@ -69,9 +74,10 @@ def tokenize_file(
     xml_escape,
     aggressive_dash_splits,
     protected_patterns,
+    custom_nb_prefixes,
     encoding,
 ):
-    moses = MosesTokenizer(lang=language)
+    moses = MosesTokenizer(lang=language, custom_nonbreaking_prefixes=custom_nb_prefixes)
 
     if protected_patterns:
         with open(protected_patterns, encoding="utf8") as fin:

--- a/sacremoses/tokenize.py
+++ b/sacremoses/tokenize.py
@@ -283,14 +283,26 @@ class MosesTokenizer(object):
         BASIC_PROTECTED_PATTERN_5,
     ]
 
-    def __init__(self, lang="en"):
+    def __init__(self, lang="en", custom_nonbreaking_prefixes=None):
         # Initialize the object.
         super(MosesTokenizer, self).__init__()
         self.lang = lang
+
         # Initialize the language specific nonbreaking prefixes.
         self.NONBREAKING_PREFIXES = [
             _nbp.strip() for _nbp in nonbreaking_prefixes.words(lang)
         ]
+
+        # Load custom nonbreaking prefixes file.
+        if custom_nonbreaking_prefixes:
+            self.NONBREAKING_PREFIXES  = []
+            with open(custom_nonbreaking_prefixes, 'r') as fin:
+                for line in fin:
+                    line = line.strip()
+                    if line and not line.startswith("#"):
+                        if line not in self.NONBREAKING_PREFIXES:
+                            self.NONBREAKING_PREFIXES.append(line)
+
         self.NUMERIC_ONLY_PREFIXES = [
             w.rpartition(" ")[0]
             for w in self.NONBREAKING_PREFIXES

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ sacremoses=sacremoses.cli:cli
 setup(
   name = 'sacremoses',
   packages = ['sacremoses'],
-  version = '0.0.31',
+  version = '0.0.32',
   description = 'SacreMoses',
   long_description = 'LGPL MosesTokenizer in Python',
   author = '',


### PR DESCRIPTION
Example usage:


```
# The custom nonbreaking pattern.
$ echo 'special.symbol' > custom_nbp.txt

# File contains the special nonbreaking pattern.
$ echo "Don't split this special.symbol up. Got it?" > in.txt

$ sacremoses tokenize -l en -c custom_nbp.txt < in.txt > out.txt
100%|██████| 1/1 [00:00<00:00,  3.57it/s]

# Voila, the new nonbreaking pattern is kept =)
$ cat out.txt 
Don &apos;t split this special.symbol up . Got it ?
```