### PR TITLE
fix detokenization to add space between non-cjk and cjk tokens

### DIFF
--- a/sacremoses/test/test_tokenizer.py
+++ b/sacremoses/test/test_tokenizer.py
@@ -318,3 +318,18 @@ class TestDetokenizer(unittest.TestCase):
         tokenizer = MosesTokenizer(lang="ja")
         text = u"電話でんわの邪魔じゃまをしないでください"
         assert tokenizer.tokenize(text) == [text]
+
+    def test_mixed_cjk_tokenization(self):
+        tokenizer = MosesTokenizer()
+        detokenizer = MosesDetokenizer()
+        text = u"Japan is 日本 in Japanese."
+        assert tokenizer.tokenize(text) == [
+            u"Japan",
+            u"is",
+            u"日",
+            u"本",
+            u"in",
+            u"Japanese",
+            u".",
+        ]
+        assert detokenizer.detokenize(tokenizer.tokenize(text)) == text

--- a/sacremoses/tokenize.py
+++ b/sacremoses/tokenize.py
@@ -689,7 +689,7 @@ class MosesDetokenizer(object):
             # Check if the first char is CJK.
             if is_cjk(token[0]) and self.lang != "ko":
                 # Perform left shift if this is a second consecutive CJK word.
-                if i > 0 and is_cjk(token[-1]):
+                if i > 0 and is_cjk(tokens[i - 1][-1]):
                     detokenized_text += token
                 # But do nothing special if this is a CJK word that doesn't follow a CJK word
                 else:


### PR DESCRIPTION
Fix for #71 to add a space between non-CJK and CJK tokens to match the original perl scripts.