### PR TITLE
Use chain.from_iterable in normalize.py

### DIFF
--- a/sacremoses/normalize.py
+++ b/sacremoses/normalize.py
@@ -159,7 +159,7 @@ class MosesPunctNormalizer:
             else:
                 self.substitutions.append(self.OTHER)
 
-        self.substitutions = list(chain(*self.substitutions))
+        self.substitutions = list(chain.from_iterable(self.substitutions))
 
         self.pre_replace_unicode_punct = pre_replace_unicode_punct
         self.post_remove_control_chars = post_remove_control_chars


### PR DESCRIPTION
This is a faster and more idiomatic way of using `itertools.chain`. Instead of computing all the items in the iterable and storing them in memory, they are computed one-by-one and never stored as a huge list. This can save on both runtime and memory space.