### PR TITLE
Improvements: virama and nukthas of Indic languages, easy way to specify basic protected patterns

### DIFF
--- a/sacremoses/__main__.py
+++ b/sacremoses/__main__.py
@@ -1,0 +1,5 @@
+#!/usr/bin/env python
+
+if __name__ == '__main__':
+    from sacremoses.cli import cli
+    cli()

--- a/sacremoses/cli.py
+++ b/sacremoses/cli.py
@@ -99,7 +99,7 @@ def parallel_or_not(iterator, func, processes, quiet):
 @click.option(
     "--protected-patterns",
     "-p",
-    help="Specify file with patters to be protected in tokenisation.",
+    help="Specify file with patters to be protected in tokenisation. Special values: :basic: :web:",
 )
 @click.option(
     "--custom-nb-prefixes",
@@ -116,8 +116,13 @@ def tokenize_file(
         custom_nonbreaking_prefixes_file=custom_nb_prefixes)
 
     if protected_patterns:
-        with open(protected_patterns, encoding="utf8") as fin:
-            protected_patterns = [pattern.strip() for pattern in fin.readlines()]
+        if protected_patterns == ':basic:':
+            protected_patterns = moses.BASIC_PROTECTED_PATTERNS
+        elif protected_patterns == ':web:':
+            protected_patterns = moses.WEB_PROTECTED_PATTERNS
+        else:
+            with open(protected_patterns, encoding="utf8") as fin:
+                protected_patterns = [pattern.strip() for pattern in fin.readlines()]
 
     moses_tokenize = partial(
         moses.tokenize,

--- a/sacremoses/indic.py
+++ b/sacremoses/indic.py
@@ -1,0 +1,73 @@
+#
+# Created by: Thamme Gowda ; June 2020
+#
+# https://en.wikipedia.org/wiki/Virama
+VIRAMAS = [
+    '\u094D',  # Devanagari ◌्
+    '\u09CD',  # Bengali ◌্
+    '\u0A4D',  # Gurmukhi ◌੍
+    '\u0ACD',  # Gujarati ◌્
+    '\u0B4D',  # Oriya ◌୍
+    '\u0BCD',  # Tamil ◌்
+    '\u0C4D',  # Telugu ◌్
+    '\u0CCD',  # Kannada ◌್
+    '\u0D3B',  # Malayalam Sign Vertical Bar ◌഻
+    '\u0D3C',  # Malayalam Sign Circular ◌഻
+    '\u0D4D',  # Malayalam ◌്
+    '\u0EBA',  # Lao Sign Pali ◌຺
+    '\u1039',  # Myanmar ◌္
+    '\u1714',  # Tagalog ◌᜔
+    '\u1BAB',  # Sundanese ◌᮫
+    '\uA8C4',  # Saurashtra ◌꣄
+    '\uA8F3',  # Devanagari Sign Candrabindu ꣳ
+    '\uA8F4',  # Devanagari Sign Double Candrabindu ꣴ
+    '\uA953',  # Rejang ꥓
+    '\uAAF6',  # Meetei Mayek ◌꫶
+    '\U00010A3F',  # Kharoshthi ◌𐨿
+    '\U00011046',  # Brahmi ◌𑁆
+    '\U000110B9',  # Kaithi ◌𑂹
+    '\U00011133',  # Chakma ◌𑄳
+    '\U000111C0',  # Sharada 𑇀
+    '\U00011235',  # Khojki 𑈵
+    '\U000112EA',  # Khudawadi ◌𑋪
+    '\U0001134D',  # Grantha 𑍍
+    '\U00011442',  # Newa ◌𑑂
+    '\U000114C2',  # Tirhuta ◌𑓂
+    '\U000115BF',  # Siddham ◌𑖿
+    '\U0001163F',  # Modi ◌𑘿
+    '\U000116B6',  # Takri 𑚶
+    '\U00011839',  # Dogra ◌𑠹
+    '\U000119E0',  # Nandinagari ◌𑧠
+    '\U00011A34',  # Zanabazar Square ◌𑨴
+    '\U00011C3F',  # Bhaiksuki ◌𑰿
+    '\U00011D45',  # Masaram Gondi ◌𑵅
+    '\U00011D97',  # Gunjala Gondi ◌𑶗
+    '\u0DCA',  # Sinhala hal kirīma ්
+]
+
+# https://en.wikipedia.org/wiki/Nuqta
+NUKTAS = [
+    '\u093C',  # Devanagari  ◌़
+    '\u09BC',  # Bengali  ◌়
+    '\u0A3C',  # Gurmukhi  ◌਼
+    '\u0ABC',  # Gujarati  ◌઼
+    '\u0AFD',  # Gujarati Sign Three-Dot  Above ◌૽
+    '\u0AFE',  # Gujarati Sign Circle  Above ◌૾
+    '\u0AFF',  # Gujarati Sign Two-Circle  Above ◌૿
+    '\u0B3C',  # Oriya  ◌଼
+    '\u0CBC',  # Kannada  ◌಼
+    '\u1C37',  # Lepcha  ◌᰷
+    '\U000110BA',  # Kaithi  ◌𑂺
+    '\U00011173',  # Mahajani  ◌𑅳
+    '\U000111CA',  # Sharada  ◌𑇊
+    '\U00011236',  # Khojki  ◌𑈶
+    '\U000112E9',  # Khudawadi  ◌𑋩
+    '\U0001133C',  # Grantha  ◌𑌼
+    '\U00011446',  # Newa  ◌𑑆
+    '\U000114C3',  # Tirhuta  ◌𑓃
+    '\U000115C0',  # Siddham  ◌𑗀
+    '\U000116B7',  # Takri  ◌𑚷
+    '\U0001183A',  # Dogra  ◌𑠺
+    '\U00011D42',  # Masaram Gondi  ◌𑵂
+    '\U0001E94A',  # Adlam  ◌𞥊
+]

--- a/sacremoses/tokenize.py
+++ b/sacremoses/tokenize.py
@@ -8,7 +8,7 @@ from six import text_type
 from sacremoses.corpus import Perluniprops
 from sacremoses.corpus import NonbreakingPrefixes
 from sacremoses.util import is_cjk
-
+from sacremoses.indic import VIRAMAS, NUKTAS
 perluniprops = Perluniprops()
 nonbreaking_prefixes = NonbreakingPrefixes()
 
@@ -21,10 +21,12 @@ class MosesTokenizer(object):
 
     # Perl Unicode Properties character sets.
     IsN = text_type("".join(perluniprops.chars("IsN")))
-    IsAlnum = text_type("".join(perluniprops.chars("IsAlnum")))  # + u'्'
+    IsAlnum = text_type("".join(perluniprops.chars("IsAlnum"))
+                        + "".join(VIRAMAS) + "".join(NUKTAS))  # + u'्'
     IsSc = text_type("".join(perluniprops.chars("IsSc")))
     IsSo = text_type("".join(perluniprops.chars("IsSo")))
-    IsAlpha = text_type("".join(perluniprops.chars("IsAlpha")))
+    IsAlpha = text_type("".join(perluniprops.chars("IsAlpha"))
+                        + "".join(VIRAMAS) + "".join(NUKTAS))
     IsLower = text_type("".join(perluniprops.chars("IsLower")))
 
     # Remove ASCII junk.
@@ -460,7 +462,6 @@ class MosesTokenizer(object):
 
         # Strips heading and trailing spaces.
         text = text.strip()
-
         # FIXME!!!
         '''
         # For Finnish and Swedish, seperate out all "other" special characters.

--- a/sacremoses/tokenize.py
+++ b/sacremoses/tokenize.py
@@ -282,6 +282,14 @@ class MosesTokenizer(object):
         BASIC_PROTECTED_PATTERN_4,
         BASIC_PROTECTED_PATTERN_5,
     ]
+    WEB_PROTECTED_PATTERNS = [
+        r'((https?|ftp|rsync)://|www\.)[^ ]*',   # URLs
+        r'[\w\-\_\.]+\@([\w\-\_]+\.)+[a-zA-Z]{2,}', # Emails user@host.domain
+        r'@[a-zA-Z0-9_]+', # @handler such as twitter/github ID
+        r'#[a-zA-Z0-9_]+', # @hashtag
+        #TODO: emojis especially the multi codepoints
+    ]
+
 
     def __init__(self, lang="en", custom_nonbreaking_prefixes_file=None):
         # Initialize the object.

--- a/sacremoses/tokenize.py
+++ b/sacremoses/tokenize.py
@@ -22,7 +22,7 @@ class MosesTokenizer(object):
     # Perl Unicode Properties character sets.
     IsN = text_type("".join(perluniprops.chars("IsN")))
     IsAlnum = text_type("".join(perluniprops.chars("IsAlnum"))
-                        + "".join(VIRAMAS) + "".join(NUKTAS))  # + u'्'
+                        + "".join(VIRAMAS) + "".join(NUKTAS))
     IsSc = text_type("".join(perluniprops.chars("IsSc")))
     IsSo = text_type("".join(perluniprops.chars("IsSo")))
     IsAlpha = text_type("".join(perluniprops.chars("IsAlpha"))


### PR DESCRIPTION
Changes  proposed:

1. Added `viramas` and `nuktas` of Indian languages --  don't butcher them
2.   `-p :basic:` to  enable basic protected patters
3.  `-p :web:` to enable protected patterns for web : @user #hashtag user@host.com https://host.com?k1=v1&k2=v2 
4. added `__main__.py` so we can call `python -m sacremoses` ; Actually useful for development like `PYTHONPATH=path/to/repo python -m sacremoses`

P.S.
1. these are some changes I made for my use case, it would be nice to merge it to main repo. If they aren't general enough, it's okay to not merge it, then I will have to maintain my own copy of this code :)
2. I don't know how bad it harmed the performance with viramas, nukthas concatenated, and extra protected patterns.  
