### PR TITLE
Fix detruecaser when the first token is all-caps

### DIFF
--- a/sacremoses/test/test_truecaser.py
+++ b/sacremoses/test/test_truecaser.py
@@ -120,3 +120,11 @@ class TestDetruecaser(unittest.TestCase):
         expected_str = "The Adventures of Sherlock Holmes"
         assert moses.detruecase(text, is_headline=True) == expected
         assert moses.detruecase(text, is_headline=True, return_str=True) == expected_str
+
+    def test_moses_detruecase_allcaps(self):
+        moses = MosesDetruecaser()
+        text = "MLB Baseball standings"
+        expected = ["MLB", "Baseball", "standings"]
+        expected_str = "MLB Baseball standings"
+        assert moses.detruecase(text) == expected
+        assert moses.detruecase(text, return_str=True) == expected_str

--- a/sacremoses/truecase.py
+++ b/sacremoses/truecase.py
@@ -505,7 +505,7 @@ class MosesDetruecaser(object):
         sentence_start = True
         # Capitalize token if it's at the sentence start.
         for token in text.split():
-            token = token.capitalize() if sentence_start else token
+            token = token[:1].upper() + token[1:] if sentence_start else token
             cased_tokens.append(token)
             if token in self.SENT_END:
                 sentence_start = True
@@ -514,7 +514,7 @@ class MosesDetruecaser(object):
         # Check if it's a headline, if so then use title case.
         if is_headline:
             cased_tokens = [
-                token if token in self.ALWAYS_LOWER else token.capitalize()
+                token if token in self.ALWAYS_LOWER else token[:1].upper() + token[1:]
                 for token in cased_tokens
             ]
 


### PR DESCRIPTION
There's a small mismatch between `MosesDetruecaser` and the [original Perl script](https://github.com/moses-smt/mosesdecoder/blob/78ca5f3cc5aa671a8a5d36c56452e217e6f00828/scripts/recaser/detruecase.perl#L91):

```bash
$ echo 'COVID @-@ 19' | perl detruecase.perl
COVID @-@ 19
$ echo 'COVID @-@ 19' | sacremoses detruecase
Covid @-@ 19
```

It's because that `str.capitalize()` capitalizes the first character and lowercase the rest.

This PR changes `token.capitalize()` to `token[:1].upper() + token[1:]` and adds a unit test for it.