### PR TITLE
Restrict click to be <8.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ sacremoses=sacremoses.cli:cli
 setup(
   name = 'sacremoses',
   packages = ['sacremoses'],
-  version = '0.0.50',
+  version = '0.0.51',
   description = 'SacreMoses',
   long_description = 'MosesTokenizer in Python',
   author = '',
@@ -20,6 +20,6 @@ setup(
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
   ],
-  install_requires = ['regex', 'six', 'click==8.0', 'joblib', 'tqdm'],
+  install_requires = ['regex', 'six', 'click<8.1', 'joblib', 'tqdm'],
   entry_points=console_scripts,
 )


### PR DESCRIPTION
Many projects use versions of `click` that aren't `8.0`, and we should allow that. Ideally, we should also figure out what caused `8.1.3` to break.

Also, apparently `8.0.0` is broken.