### PR TITLE
compile regex objects ahead of time for improved perf.

### DIFF
--- a/sacremoses/tokenize.py
+++ b/sacremoses/tokenize.py
@@ -33,8 +33,8 @@ class MosesTokenizer(object):
     IsLower = text_type("".join(perluniprops.chars("IsLower")))
 
     # Remove ASCII junk.
-    DEDUPLICATE_SPACE = r"\s+", r" "
-    ASCII_JUNK = r"[\000-\037]", r""
+    DEDUPLICATE_SPACE = re.compile(r"\s+"), r" "
+    ASCII_JUNK = re.compile(r"[\000-\037]"), r""
 
     # Neurotic Perl heading space, multi-space and trailing space chomp.
     # These regexes are kept for reference purposes and shouldn't be used!!
@@ -43,51 +43,51 @@ class MosesTokenizer(object):
     RIGHT_STRIP = r" $", r""  # Uses text.rstrip() instead.
 
     # Pad all "other" special characters not in IsAlnum.
-    PAD_NOT_ISALNUM = r"([^{}\s\.'\`\,\-])".format(IsAlnum), r" \1 "
+    PAD_NOT_ISALNUM = re.compile(r"([^{}\s\.'\`\,\-])".format(IsAlnum)), r" \1 "
 
     # Splits all hyphens (regardless of circumstances), e.g.
     # 'foo-bar' -> 'foo @-@ bar'
     AGGRESSIVE_HYPHEN_SPLIT = (
-        r"([{alphanum}])\-(?=[{alphanum}])".format(alphanum=IsAlnum),
+        re.compile(r"([{alphanum}])\-(?=[{alphanum}])".format(alphanum=IsAlnum)),
         r"\1 @-@ ",
     )
 
     # Make multi-dots stay together.
-    REPLACE_DOT_WITH_LITERALSTRING_1 = r"\.([\.]+)", " DOTMULTI\1"
-    REPLACE_DOT_WITH_LITERALSTRING_2 = r"DOTMULTI\.([^\.])", "DOTDOTMULTI \1"
-    REPLACE_DOT_WITH_LITERALSTRING_3 = r"DOTMULTI\.", "DOTDOTMULTI"
+    REPLACE_DOT_WITH_LITERALSTRING_1 = re.compile(r"\.([\.]+)"), " DOTMULTI\1"
+    REPLACE_DOT_WITH_LITERALSTRING_2 = re.compile(r"DOTMULTI\.([^\.])"), "DOTDOTMULTI \1"
+    REPLACE_DOT_WITH_LITERALSTRING_3 = re.compile(r"DOTMULTI\."), "DOTDOTMULTI"
 
     # Separate out "," except if within numbers (5,300)
     # e.g.  A,B,C,D,E > A , B,C , D,E
     # First application uses up B so rule can't see B,C
     # two-step version here may create extra spaces but these are removed later
     # will also space digit,letter or letter,digit forms (redundant with next section)
-    COMMA_SEPARATE_1 = r"([^{}])[,]".format(IsN), r"\1 , "
-    COMMA_SEPARATE_2 = r"[,]([^{}])".format(IsN), r" , \1"
-    COMMA_SEPARATE_3 = r"([{}])[,]$".format(IsN), r"\1 , "
+    COMMA_SEPARATE_1 = re.compile(r"([^{}])[,]".format(IsN)), r"\1 , "
+    COMMA_SEPARATE_2 = re.compile(r"[,]([^{}])".format(IsN)), r" , \1"
+    COMMA_SEPARATE_3 = re.compile(r"([{}])[,]$".format(IsN)), r"\1 , "
 
     # Attempt to get correct directional quotes.
-    DIRECTIONAL_QUOTE_1 = r"^``", r"`` "
-    DIRECTIONAL_QUOTE_2 = r'^"', r"`` "
-    DIRECTIONAL_QUOTE_3 = r"^`([^`])", r"` \1"
-    DIRECTIONAL_QUOTE_4 = r"^'", r"`  "
-    DIRECTIONAL_QUOTE_5 = r'([ ([{<])"', r"\1 `` "
-    DIRECTIONAL_QUOTE_6 = r"([ ([{<])``", r"\1 `` "
-    DIRECTIONAL_QUOTE_7 = r"([ ([{<])`([^`])", r"\1 ` \2"
-    DIRECTIONAL_QUOTE_8 = r"([ ([{<])'", r"\1 ` "
+    DIRECTIONAL_QUOTE_1 = re.compile(r"^``"), r"`` "
+    DIRECTIONAL_QUOTE_2 = re.compile(r'^"'), r"`` "
+    DIRECTIONAL_QUOTE_3 = re.compile(r"^`([^`])"), r"` \1"
+    DIRECTIONAL_QUOTE_4 = re.compile(r"^'"), r"`  "
+    DIRECTIONAL_QUOTE_5 = re.compile(r'([ ([{<])"'), r"\1 `` "
+    DIRECTIONAL_QUOTE_6 = re.compile(r"([ ([{<])``"), r"\1 `` "
+    DIRECTIONAL_QUOTE_7 = re.compile(r"([ ([{<])`([^`])"), r"\1 ` \2"
+    DIRECTIONAL_QUOTE_8 = re.compile(r"([ ([{<])'"), r"\1 ` "
 
     # Replace ... with _ELLIPSIS_
-    REPLACE_ELLIPSIS = r"\.\.\.", r" _ELLIPSIS_ "
+    REPLACE_ELLIPSIS = re.compile(r"\.\.\."), r" _ELLIPSIS_ "
     # Restore _ELLIPSIS_ with ...
-    RESTORE_ELLIPSIS = r"_ELLIPSIS_", r"\.\.\."
+    RESTORE_ELLIPSIS = re.compile(r"_ELLIPSIS_"), r"\.\.\."
 
     # Pad , with tailing space except if within numbers, e.g. 5,300
-    COMMA_1 = r"([^{numbers}])[,]([^{numbers}])".format(numbers=IsN), r"\1 , \2"
-    COMMA_2 = r"([{numbers}])[,]([^{numbers}])".format(numbers=IsN), r"\1 , \2"
-    COMMA_3 = r"([^{numbers}])[,]([{numbers}])".format(numbers=IsN), r"\1 , \2"
+    COMMA_1 = re.compile(r"([^{numbers}])[,]([^{numbers}])".format(numbers=IsN)), r"\1 , \2"
+    COMMA_2 = re.compile(r"([{numbers}])[,]([^{numbers}])".format(numbers=IsN)), r"\1 , \2"
+    COMMA_3 = re.compile(r"([^{numbers}])[,]([{numbers}])".format(numbers=IsN)), r"\1 , \2"
 
     # Pad unicode symbols with spaces.
-    SYMBOLS = r"([;:@#\$%&{}{}])".format(IsSc, IsSo), r" \1 "
+    SYMBOLS = re.compile(r"([;:@#\$%&{}{}])".format(IsSc, IsSo)), r" \1 "
 
     # Separate out intra-token slashes.  PTB tokenization doesn't do this, so
     # the tokens should be merged prior to parsing with a PTB-trained parser.
@@ -98,80 +98,80 @@ class MosesTokenizer(object):
     )
 
     # Splits final period at end of string.
-    FINAL_PERIOD = r"""([^.])([.])([\]\)}>"']*) ?$""", r"\1 \2\3"
+    FINAL_PERIOD = re.compile(r"""([^.])([.])([\]\)}>"']*) ?$"""), r"\1 \2\3"
     # Pad all question marks and exclamation marks with spaces.
-    PAD_QUESTION_EXCLAMATION_MARK = r"([?!])", r" \1 "
+    PAD_QUESTION_EXCLAMATION_MARK = re.compile(r"([?!])"), r" \1 "
 
     # Handles parentheses, brackets and converts them to PTB symbols.
-    PAD_PARENTHESIS = r"([\]\[\(\){}<>])", r" \1 "
-    CONVERT_PARENTHESIS_1 = r"\(", "-LRB-"
-    CONVERT_PARENTHESIS_2 = r"\)", "-RRB-"
-    CONVERT_PARENTHESIS_3 = r"\[", "-LSB-"
-    CONVERT_PARENTHESIS_4 = r"\]", "-RSB-"
-    CONVERT_PARENTHESIS_5 = r"\{", "-LCB-"
-    CONVERT_PARENTHESIS_6 = r"\}", "-RCB-"
+    PAD_PARENTHESIS = re.compile(r"([\]\[\(\){}<>])"), r" \1 "
+    CONVERT_PARENTHESIS_1 = re.compile(r"\("), "-LRB-"
+    CONVERT_PARENTHESIS_2 = re.compile(r"\)"), "-RRB-"
+    CONVERT_PARENTHESIS_3 = re.compile(r"\["), "-LSB-"
+    CONVERT_PARENTHESIS_4 = re.compile(r"\]"), "-RSB-"
+    CONVERT_PARENTHESIS_5 = re.compile(r"\{"), "-LCB-"
+    CONVERT_PARENTHESIS_6 = re.compile(r"\}"), "-RCB-"
 
     # Pads double dashes with spaces.
-    PAD_DOUBLE_DASHES = r"--", " -- "
+    PAD_DOUBLE_DASHES = re.compile(r"--"), " -- "
 
     # Adds spaces to start and end of string to simplify further regexps.
-    PAD_START_OF_STR = r"^", " "
-    PAD_END_OF_STR = r"$", " "
+    PAD_START_OF_STR = re.compile(r"^"), " "
+    PAD_END_OF_STR = re.compile(r"$"), " "
 
     # Converts double quotes to two single quotes and pad with spaces.
-    CONVERT_DOUBLE_TO_SINGLE_QUOTES = r'"', " '' "
+    CONVERT_DOUBLE_TO_SINGLE_QUOTES = re.compile(r'"'), " '' "
     # Handles single quote in possessives or close-single-quote.
-    HANDLES_SINGLE_QUOTES = r"([^'])' ", r"\1 ' "
+    HANDLES_SINGLE_QUOTES = re.compile(r"([^'])' "), r"\1 ' "
 
     # Pad apostrophe in possessive or close-single-quote.
-    APOSTROPHE = r"([^'])'", r"\1 ' "
+    APOSTROPHE = re.compile(r"([^'])'"), r"\1 ' "
 
     # Prepend space on contraction apostrophe.
-    CONTRACTION_1 = r"'([sSmMdD]) ", r" '\1 "
-    CONTRACTION_2 = r"'ll ", r" 'll "
-    CONTRACTION_3 = r"'re ", r" 're "
-    CONTRACTION_4 = r"'ve ", r" 've "
-    CONTRACTION_5 = r"n't ", r" n't "
-    CONTRACTION_6 = r"'LL ", r" 'LL "
-    CONTRACTION_7 = r"'RE ", r" 'RE "
-    CONTRACTION_8 = r"'VE ", r" 'VE "
-    CONTRACTION_9 = r"N'T ", r" N'T "
+    CONTRACTION_1 = re.compile(r"'([sSmMdD]) "), r" '\1 "
+    CONTRACTION_2 = re.compile(r"'ll "), r" 'll "
+    CONTRACTION_3 = re.compile(r"'re "), r" 're "
+    CONTRACTION_4 = re.compile(r"'ve "), r" 've "
+    CONTRACTION_5 = re.compile(r"n't "), r" n't "
+    CONTRACTION_6 = re.compile(r"'LL "), r" 'LL "
+    CONTRACTION_7 = re.compile(r"'RE "), r" 'RE "
+    CONTRACTION_8 = re.compile(r"'VE "), r" 'VE "
+    CONTRACTION_9 = re.compile(r"N'T "), r" N'T "
 
     # Informal Contractions.
-    CONTRACTION_10 = r" ([Cc])annot ", r" \1an not "
-    CONTRACTION_11 = r" ([Dd])'ye ", r" \1' ye "
-    CONTRACTION_12 = r" ([Gg])imme ", r" \1im me "
-    CONTRACTION_13 = r" ([Gg])onna ", r" \1on na "
-    CONTRACTION_14 = r" ([Gg])otta ", r" \1ot ta "
-    CONTRACTION_15 = r" ([Ll])emme ", r" \1em me "
-    CONTRACTION_16 = r" ([Mm])ore'n ", r" \1ore 'n "
-    CONTRACTION_17 = r" '([Tt])is ", r" '\1 is "
-    CONTRACTION_18 = r" '([Tt])was ", r" '\1 was "
-    CONTRACTION_19 = r" ([Ww])anna ", r" \1an na "
+    CONTRACTION_10 = re.compile(r" ([Cc])annot "), r" \1an not "
+    CONTRACTION_11 = re.compile(r" ([Dd])'ye "), r" \1' ye "
+    CONTRACTION_12 = re.compile(r" ([Gg])imme "), r" \1im me "
+    CONTRACTION_13 = re.compile(r" ([Gg])onna "), r" \1on na "
+    CONTRACTION_14 = re.compile(r" ([Gg])otta "), r" \1ot ta "
+    CONTRACTION_15 = re.compile(r" ([Ll])emme "), r" \1em me "
+    CONTRACTION_16 = re.compile(r" ([Mm])ore'n "), r" \1ore 'n "
+    CONTRACTION_17 = re.compile(r" '([Tt])is "), r" '\1 is "
+    CONTRACTION_18 = re.compile(r" '([Tt])was "), r" '\1 was "
+    CONTRACTION_19 = re.compile(r" ([Ww])anna "), r" \1an na "
 
     # Clean out extra spaces
-    CLEAN_EXTRA_SPACE_1 = r"  *", r" "
-    CLEAN_EXTRA_SPACE_2 = r"^ *", r""
-    CLEAN_EXTRA_SPACE_3 = r" *$", r""
+    CLEAN_EXTRA_SPACE_1 = re.compile(r"  *"), r" "
+    CLEAN_EXTRA_SPACE_2 = re.compile(r"^ *"), r""
+    CLEAN_EXTRA_SPACE_3 = re.compile(r" *$"), r""
 
     # Neurotic Perl regexes to escape special characters.
-    ESCAPE_AMPERSAND = r"&", r"&amp;"
-    ESCAPE_PIPE = r"\|", r"&#124;"
-    ESCAPE_LEFT_ANGLE_BRACKET = r"<", r"&lt;"
-    ESCAPE_RIGHT_ANGLE_BRACKET = r">", r"&gt;"
-    ESCAPE_SINGLE_QUOTE = r"\'", r"&apos;"
-    ESCAPE_DOUBLE_QUOTE = r"\"", r"&quot;"
-    ESCAPE_LEFT_SQUARE_BRACKET = r"\[", r"&#91;"
-    ESCAPE_RIGHT_SQUARE_BRACKET = r"]", r"&#93;"
+    ESCAPE_AMPERSAND = re.compile(r"&"), r"&amp;"
+    ESCAPE_PIPE = re.compile(r"\|"), r"&#124;"
+    ESCAPE_LEFT_ANGLE_BRACKET = re.compile(r"<"), r"&lt;"
+    ESCAPE_RIGHT_ANGLE_BRACKET = re.compile(r">"), r"&gt;"
+    ESCAPE_SINGLE_QUOTE = re.compile(r"\'"), r"&apos;"
+    ESCAPE_DOUBLE_QUOTE = re.compile(r"\""), r"&quot;"
+    ESCAPE_LEFT_SQUARE_BRACKET = re.compile(r"\["), r"&#91;"
+    ESCAPE_RIGHT_SQUARE_BRACKET = re.compile(r"]"), r"&#93;"
 
-    EN_SPECIFIC_1 = r"([^{alpha}])[']([^{alpha}])".format(alpha=IsAlpha), r"\1 ' \2"
+    EN_SPECIFIC_1 = re.compile(r"([^{alpha}])[']([^{alpha}])".format(alpha=IsAlpha)), r"\1 ' \2"
     EN_SPECIFIC_2 = (
-        r"([^{alpha}{isn}])[']([{alpha}])".format(alpha=IsAlpha, isn=IsN),
+        re.compile(r"([^{alpha}{isn}])[']([{alpha}])".format(alpha=IsAlpha, isn=IsN)),
         r"\1 ' \2",
     )
-    EN_SPECIFIC_3 = r"([{alpha}])[']([^{alpha}])".format(alpha=IsAlpha), r"\1 ' \2"
-    EN_SPECIFIC_4 = r"([{alpha}])[']([{alpha}])".format(alpha=IsAlpha), r"\1 '\2"
-    EN_SPECIFIC_5 = r"([{isn}])[']([s])".format(isn=IsN), r"\1 '\2"
+    EN_SPECIFIC_3 = re.compile(r"([{alpha}])[']([^{alpha}])".format(alpha=IsAlpha)), r"\1 ' \2"
+    EN_SPECIFIC_4 = re.compile(r"([{alpha}])[']([{alpha}])".format(alpha=IsAlpha)), r"\1 '\2"
+    EN_SPECIFIC_5 = re.compile(r"([{isn}])[']([s])".format(isn=IsN)), r"\1 '\2"
 
     ENGLISH_SPECIFIC_APOSTROPHE = [
         EN_SPECIFIC_1,
@@ -181,10 +181,10 @@ class MosesTokenizer(object):
         EN_SPECIFIC_5,
     ]
 
-    FR_IT_SPECIFIC_1 = r"([^{alpha}])[']([^{alpha}])".format(alpha=IsAlpha), r"\1 ' \2"
-    FR_IT_SPECIFIC_2 = r"([^{alpha}])[']([{alpha}])".format(alpha=IsAlpha), r"\1 ' \2"
-    FR_IT_SPECIFIC_3 = r"([{alpha}])[']([^{alpha}])".format(alpha=IsAlpha), r"\1 ' \2"
-    FR_IT_SPECIFIC_4 = r"([{alpha}])[']([{alpha}])".format(alpha=IsAlpha), r"\1' \2"
+    FR_IT_SPECIFIC_1 = re.compile(r"([^{alpha}])[']([^{alpha}])".format(alpha=IsAlpha)), r"\1 ' \2"
+    FR_IT_SPECIFIC_2 = re.compile(r"([^{alpha}])[']([{alpha}])".format(alpha=IsAlpha)), r"\1 ' \2"
+    FR_IT_SPECIFIC_3 = re.compile(r"([{alpha}])[']([^{alpha}])".format(alpha=IsAlpha)), r"\1 ' \2"
+    FR_IT_SPECIFIC_4 = re.compile(r"([{alpha}])[']([{alpha}])".format(alpha=IsAlpha)), r"\1' \2"
 
     FR_IT_SPECIFIC_APOSTROPHE = [
         FR_IT_SPECIFIC_1,
@@ -193,9 +193,9 @@ class MosesTokenizer(object):
         FR_IT_SPECIFIC_4,
     ]
 
-    NON_SPECIFIC_APOSTROPHE = r"\'", " ' "
+    NON_SPECIFIC_APOSTROPHE = re.compile(r"\'"), " ' "
 
-    TRAILING_DOT_APOSTROPHE = r"\.' ?$", " . ' "
+    TRAILING_DOT_APOSTROPHE = re.compile(r"\.' ?$"), " . ' "
 
     BASIC_PROTECTED_PATTERN_1 = r"<\/?\S+\/?>"
     BASIC_PROTECTED_PATTERN_2 = r'<\S+( [a-zA-Z0-9]+\="?[^"]")+ ?\/?>'
@@ -334,26 +334,28 @@ class MosesTokenizer(object):
             self.IsAlpha += cjk_chars
             self.IsAlnum += cjk_chars
             # Overwrite the alnum regexes.
-            self.PAD_NOT_ISALNUM = r"([^{}\s\.'\`\,\-])".format(self.IsAlnum), r" \1 "
+            self.PAD_NOT_ISALNUM = re.compile(r"([^{}\s\.'\`\,\-])".format(self.IsAlnum)), r" \1 "
             self.AGGRESSIVE_HYPHEN_SPLIT = (
-                r"([{alphanum}])\-(?=[{alphanum}])".format(alphanum=self.IsAlnum),
+                re.compile(r"([{alphanum}])\-(?=[{alphanum}])".format(alphanum=self.IsAlnum)),
                 r"\1 @-@ ",
             )
             self.INTRATOKEN_SLASHES = (
-                r"([{alphanum}])\/([{alphanum}])".format(alphanum=self.IsAlnum),
+                re.compile(r"([{alphanum}])\/([{alphanum}])".format(alphanum=self.IsAlnum)),
                 r"$1 \@\/\@ $2",
             )
 
     def replace_multidots(self, text):
         text = re.sub(r"\.([\.]+)", r" DOTMULTI\1", text)
-        while re.search(r"DOTMULTI\.", text):
+        dotmulti = re.compile(r"DOTMULTI\.")
+        while dotmulti.search(text):
             text = re.sub(r"DOTMULTI\.([^\.])", r"DOTDOTMULTI \1", text)
-            text = re.sub(r"DOTMULTI\.", "DOTDOTMULTI", text)
+            text = dotmulti.sub("DOTDOTMULTI", text)
         return text
 
     def restore_multidots(self, text):
-        while re.search(r"DOTDOTMULTI", text):
-            text = re.sub(r"DOTDOTMULTI", r"DOTMULTI.", text)
+        dotmulti = re.compile(r"DOTDOTMULTI")
+        while dotmulti.search(text):
+            text = dotmulti.sub(r"DOTMULTI.", text)
         return re.sub(r"DOTMULTI", r".", text)
 
     def islower(self, text):
@@ -408,7 +410,7 @@ class MosesTokenizer(object):
 
     def escape_xml(self, text):
         for regexp, substitution in self.MOSES_ESCAPE_XML_REGEXES:
-            text = re.sub(regexp, substitution, text)
+            text = regexp.sub(substitution, text)
         return text
 
     def penn_tokenize(self, text, return_str=False):
@@ -420,12 +422,12 @@ class MosesTokenizer(object):
         text = text_type(text)
         # Perform a chain of regex substituitions using MOSES_PENN_REGEXES_1
         for regexp, substitution in self.MOSES_PENN_REGEXES_1:
-            text = re.sub(regexp, substitution, text)
+            text = regexp.sub(substitution, text)
         # Handles nonbreaking prefixes.
         text = self.handles_nonbreaking_prefixes(text)
         # Restore ellipsis, clean extra spaces, escape XML symbols.
         for regexp, substitution in self.MOSES_PENN_REGEXES_2:
-            text = re.sub(regexp, substitution, text)
+            text = regexp.sub(substitution, text)
         return text if return_str else text.split()
 
     def tokenize(
@@ -448,14 +450,15 @@ class MosesTokenizer(object):
         text = text_type(text)
         # De-duplicate spaces and clean ASCII junk
         for regexp, substitution in [self.DEDUPLICATE_SPACE, self.ASCII_JUNK]:
-            text = re.sub(regexp, substitution, text)
+            text = regexp.sub(substitution, text)
 
         if protected_patterns:
+            protected_patterns = [re.compile(p, re.IGNORECASE) for p in protected_patterns]
             # Find the tokens that needs to be protected.
             protected_tokens = [
                 match.group()
                 for protected_pattern in protected_patterns
-                for match in re.finditer(protected_pattern, text, re.IGNORECASE)
+                for match in protected_pattern.finditer(text)
             ]
             # Apply the protected_patterns.
             for i, token in enumerate(protected_tokens):
@@ -472,20 +475,20 @@ class MosesTokenizer(object):
             # as an apostrophe-like character:
             # USA:n, 20:een, EU:ssa, USA:s, S:t
             regexp, substitution = self.FI_SV_COLON_APOSTROPHE
-            text = re.sub(regexp, substitution, text)
+            text = regexp.sub(substitution, text)
             # If a colon is not immediately followed by lower-case characters,
             # separate it out anyway.
             regexp, substitution = self.FI_SV_COLON_NO_LOWER_FOLLOW
-            text = re.sub(regexp, substitution, text)
+            text = regexp.sub(substitution, text)
         else:
         """
         # Separate special characters outside of IsAlnum character set.
         regexp, substitution = self.PAD_NOT_ISALNUM
-        text = re.sub(regexp, substitution, text)
+        text = regexp.sub(substitution, text)
         # Aggressively splits dashes
         if aggressive_dash_splits:
             regexp, substitution = self.AGGRESSIVE_HYPHEN_SPLIT
-            text = re.sub(regexp, substitution, text)
+            text = regexp.sub(substitution, text)
 
         # Replaces multidots with "DOTDOTMULTI" literal strings.
         text = self.replace_multidots(text)
@@ -496,31 +499,31 @@ class MosesTokenizer(object):
             self.COMMA_SEPARATE_2,
             self.COMMA_SEPARATE_3,
         ]:
-            text = re.sub(regexp, substitution, text)
+            text = regexp.sub(substitution, text)
 
         # (Language-specific) apostrophe tokenization.
         if self.lang == "en":
             for regexp, substitution in self.ENGLISH_SPECIFIC_APOSTROPHE:
-                text = re.sub(regexp, substitution, text)
+                text = regexp.sub(substitution, text)
         elif self.lang in ["fr", "it"]:
             for regexp, substitution in self.FR_IT_SPECIFIC_APOSTROPHE:
-                text = re.sub(regexp, substitution, text)
+                text = regexp.sub(substitution, text)
         # FIXME!!!
         ##elif self.lang == "so":
         ##    for regexp, substitution in self.SO_SPECIFIC_APOSTROPHE:
         ##        text = re.sub(regexp, substitution, text)
         else:
             regexp, substitution = self.NON_SPECIFIC_APOSTROPHE
-            text = re.sub(regexp, substitution, text)
+            text = regexp.sub(substitution, text)
 
         # Handles nonbreaking prefixes.
         text = self.handles_nonbreaking_prefixes(text)
         # Cleans up extraneous spaces.
         regexp, substitution = self.DEDUPLICATE_SPACE
-        text = re.sub(regexp, substitution, text).strip()
+        text = regexp.sub(substitution, text).strip()
         # Split trailing ".'".
         regexp, substituition = self.TRAILING_DOT_APOSTROPHE
-        text = re.sub(regexp, substituition, text)
+        text = regexp.sub(substituition, text)
 
         # Restore the protected tokens.
         if protected_patterns:
@@ -549,24 +552,24 @@ class MosesDetokenizer(object):
     IsAlpha = text_type("".join(perluniprops.chars("IsAlpha")))
     IsSc = text_type("".join(perluniprops.chars("IsSc")))
 
-    AGGRESSIVE_HYPHEN_SPLIT = r" \@\-\@ ", r"-"
+    AGGRESSIVE_HYPHEN_SPLIT = re.compile(r" \@\-\@ "), r"-"
 
     # Merge multiple spaces.
     ONE_SPACE = re.compile(r" {2,}"), " "
 
     # Unescape special characters.
-    UNESCAPE_FACTOR_SEPARATOR = r"&#124;", r"|"
-    UNESCAPE_LEFT_ANGLE_BRACKET = r"&lt;", r"<"
-    UNESCAPE_RIGHT_ANGLE_BRACKET = r"&gt;", r">"
-    UNESCAPE_DOUBLE_QUOTE = r"&quot;", r'"'
-    UNESCAPE_SINGLE_QUOTE = r"&apos;", r"'"
-    UNESCAPE_SYNTAX_NONTERMINAL_LEFT = r"&#91;", r"["
-    UNESCAPE_SYNTAX_NONTERMINAL_RIGHT = r"&#93;", r"]"
-    UNESCAPE_AMPERSAND = r"&amp;", r"&"
+    UNESCAPE_FACTOR_SEPARATOR = re.compile(r"&#124;"), r"|"
+    UNESCAPE_LEFT_ANGLE_BRACKET = re.compile(r"&lt;"), r"<"
+    UNESCAPE_RIGHT_ANGLE_BRACKET = re.compile(r"&gt;"), r">"
+    UNESCAPE_DOUBLE_QUOTE = re.compile(r"&quot;"), r'"'
+    UNESCAPE_SINGLE_QUOTE = re.compile(r"&apos;"), r"'"
+    UNESCAPE_SYNTAX_NONTERMINAL_LEFT = re.compile(r"&#91;"), r"["
+    UNESCAPE_SYNTAX_NONTERMINAL_RIGHT = re.compile(r"&#93;"), r"]"
+    UNESCAPE_AMPERSAND = re.compile(r"&amp;"), r"&"
     # The legacy regexes are used to support outputs from older Moses versions.
-    UNESCAPE_FACTOR_SEPARATOR_LEGACY = r"&bar;", r"|"
-    UNESCAPE_SYNTAX_NONTERMINAL_LEFT_LEGACY = r"&bra;", r"["
-    UNESCAPE_SYNTAX_NONTERMINAL_RIGHT_LEGACY = r"&ket;", r"]"
+    UNESCAPE_FACTOR_SEPARATOR_LEGACY = re.compile(r"&bar;"), r"|"
+    UNESCAPE_SYNTAX_NONTERMINAL_LEFT_LEGACY = re.compile(r"&bra;"), r"["
+    UNESCAPE_SYNTAX_NONTERMINAL_RIGHT_LEGACY = re.compile(r"&ket;"), r"]"
 
     MOSES_UNESCAPE_XML_REGEXES = [
         UNESCAPE_FACTOR_SEPARATOR_LEGACY,
@@ -653,11 +656,11 @@ class MosesDetokenizer(object):
         u"kin",
     ]
 
-    FINNISH_REGEX = r"^({})({})?({})$".format(
+    FINNISH_REGEX = re.compile(r"^({})({})?({})$".format(
         text_type("|".join(FINNISH_MORPHSET_1)),
         text_type("|".join(FINNISH_MORPHSET_2)),
         text_type("|".join(FINNISH_MORPHSET_3)),
-    )
+    ))
 
     def __init__(self, lang="en"):
         super(MosesDetokenizer, self).__init__()
@@ -665,7 +668,7 @@ class MosesDetokenizer(object):
 
     def unescape_xml(self, text):
         for regexp, substitution in self.MOSES_UNESCAPE_XML_REGEXES:
-            text = re.sub(regexp, substitution, text)
+            text = regexp.sub(substitution, text)
         return text
 
     def tokenize(self, tokens, return_str=True, unescape=True):
@@ -681,7 +684,7 @@ class MosesDetokenizer(object):
         text = text_type(text)
         # Detokenize the agressive hyphen split.
         regexp, substitution = self.AGGRESSIVE_HYPHEN_SPLIT
-        text = re.sub(regexp, substitution, text)
+        text = regexp.sub(substitution, text)
         if unescape:
             # Unescape the XML symbols.
             text = self.unescape_xml(text)
@@ -815,7 +818,7 @@ class MosesDetokenizer(object):
 
         # Merge multiple spaces.
         regexp, substitution = self.ONE_SPACE
-        detokenized_text = re.sub(regexp, substitution, detokenized_text)
+        detokenized_text = regexp.sub(substitution, detokenized_text)
         # Removes heading and trailing spaces.
         detokenized_text = detokenized_text.strip()
 


### PR DESCRIPTION
Compiles regexs where appropriate for improved perf for common operations (subs, searches, matches, finditers). Timeit info below for a microbenchmark (`MT1` is original w/o compilation, `MT2` is new w/ compilation).

```python
In [1]: lines = [line.strip() for line in open('big.txt') if line.strip()][:1000]

In [2]: from sacremoses.tokenize import MosesTokenizer as MT1

In [3]: from sacremoses.tokenize2 import MosesTokenizer as MT2

In [4]: mt1, mt2 = MT1(lang='en'), MT2(lang='en')

In [5]: %timeit [mt1.tokenize(line) for line in lines]
714 ms ± 18.1 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

In [6]: %timeit [mt2.tokenize(line) for line in lines]
658 ms ± 11 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```